### PR TITLE
Enable Travis-CI testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .pytest_cache/
 tests/__pycache__/
 .DS_Store
+venv

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+python:
+  - 3.6
+services:
+  - docker
+install:
+  - docker build -t max-news-text-generator .
+  - docker run -it -d -p 5000:5000 max-news-text-generator
+  - sleep 30
+before_script:
+  - pip install pytest requests
+script:
+  - pytest tests/test.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ COPY requirements.txt /workspace
 RUN pip install -r requirements.txt
 
 COPY . /workspace
+RUN md5sum -c md5sums.txt # check file integrity
 
 EXPOSE 5000
 

--- a/md5sums.txt
+++ b/md5sums.txt
@@ -1,0 +1,17 @@
+07f74340464d4e7aa1c1faa4389639c4  data/ckpt-base
+ee9f34986c458180e21a2358d229ff0e  data/ckpt-char-embedding
+85f1bfb2ac77b23449afb790eb3722c5  data/ckpt-lstm
+1cd02bc7ff542e8d206f12cacc6f9004  data/ckpt-softmax0
+e9350b4ef403cf0edfd6df8b349ed44a  data/ckpt-softmax1
+c1ac2c5459d56c9165b451bd362d27b1  data/ckpt-softmax2
+4d1c732bd56f408f48dd78b4d85cf168  data/ckpt-softmax3
+f23de860ea468406c8cfe59087e3e3bf  data/ckpt-softmax4
+6fbc354d4bafaca7b98ca1758a29a9ce  data/ckpt-softmax5
+645383201795d27ef2e17af90ca7ece1  data/ckpt-softmax6
+2e39a884fbb17bed30d31ce7ca04bfe6  data/ckpt-softmax7
+8248d2d8d3b52ff071761ea90f5f3a85  data/ckpt-softmax8
+bc326fe22e068d4614331447b42d76c1  data/graph-2016-09-10.pbtxt
+ce114e4501d2f4e2dcea3e17b546f339  data/sample1.txt
+cb2bd231beb9a8b84ac9ca8fec8912b2  data/sample2.txt
+e6376fef0b7ce023e0f871a206f15d93  data/sample3.txt
+875cbcabfebae95fac1523cb58db92b5  data/vocab-2016-09-10.txt

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,8 +1,37 @@
 import pytest
 import requests
+import os
 
 
-def test_response():
+def test_swagger():
+
+    model_endpoint = 'http://localhost:5000/swagger.json'
+
+    r = requests.get(url=model_endpoint)
+    assert r.status_code == 200
+    assert r.headers['Content-Type'] == 'application/json'
+
+    json = r.json()
+    assert 'swagger' in json
+    assert json.get('info') and json.get('info').get('title') == 'Model Asset Exchange Server'
+
+
+def test_metadata():
+
+    model_endpoint = 'http://localhost:5000/model/metadata'
+
+    r = requests.get(url=model_endpoint)
+    assert r.status_code == 200
+
+    metadata = r.json()
+    assert metadata['id'] == 'lm_1b'
+    assert metadata['name'] == 'lm_1b TensorFlow Model'
+    assert metadata['description'] == 'Generative language model trained on the One Billion Words data set'
+    assert metadata['license'] == 'Apache v2'
+
+
+@pytest.mark.skipif("TRAVIS" in os.environ, reason="test runs out of memory on Travis-CI")
+def test_predict():
     model_endpoint = 'http://localhost:5000/model/predict'
     file_path = 'data/sample1.txt'
 


### PR DESCRIPTION
- Skip the prediction endpoint on Travis CI due to memory constraints
- Test other endpoints on Travis CI
- Added venv to .gitignore
- Verify MD5 hashes of downloaded files