### PR TITLE
Add RHOS deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,12 @@ Rafal Jozefowicz, Oriol Vinyals, Mike Schuster, Noam Shazeer: “Exploring the L
 * `docker`: The [Docker](https://www.docker.com/) command-line interface. Follow the [installation instructions](https://docs.docker.com/install/) for your system.
 * The minimum recommended resources for this model is 8 GB Memory and 4 CPUs.
 
-# Steps
+# Deployment options
 
-1. [Deploy from Docker Hub](#deploy-from-docker-hub)
-2. [Deploy on Kubernetes](#deploy-on-kubernetes)
-3. [Run Locally](#run-locally)
+* [Deploy from Docker Hub](#deploy-from-docker-hub)
+* [Deploy on Red Hat OpenShift](#deploy-on-red-hat-openshift)
+* [Deploy on Kubernetes](#deploy-on-kubernetes)
+* [Run Locally](#run-locally)
 
 ## Deploy from Docker Hub
 
@@ -55,6 +56,10 @@ $ docker run -it -p 5000:5000 codait/max-news-text-generator
 
 This will pull a pre-built image from Docker Hub (or use an existing image if already cached locally) and run it.
 If you'd rather checkout and build the model locally you can follow the [run locally](#run-locally) steps below.
+
+## Deploy on Red Hat OpenShift
+
+You can deploy the model-serving microservice on Red Hat OpenShift by following the instructions for the OpenShift web console or the OpenShift Container Platform CLI [in this tutorial](https://developer.ibm.com/tutorials/deploy-a-model-asset-exchange-microservice-on-red-hat-openshift/), specifying `codait/max-news-text-generator` as the image name.
 
 ## Deploy on Kubernetes
 


### PR DESCRIPTION
Note: Travis CI is unable to fully test this model due to memory limitations. Please verify the Docker Actions tests
passed and/or run tests locally.

To run the test locally follow [the instructions](../README.md#1-build-the-model) in the README to build and run the model,
then run `pytest tests/tests.py`. See [.travis.yml](../.travis.yml) for an example.
